### PR TITLE
【Fixed】:swipeのjsが読み込まれないエラー解消

### DIFF
--- a/app/javascript/src/swipe.js
+++ b/app/javascript/src/swipe.js
@@ -1,6 +1,5 @@
-if(location.pathname === "/users") {
-
-  $(function() {
+$(document).on("turbolinks:load", function() {
+  if(location.pathname === "/users") {
     let allCards = $(".swipe--card");
     let swipeContainer = $(".swipe")[0];
 
@@ -107,5 +106,5 @@ if(location.pathname === "/users") {
         }
       });
     });
-  });
-}
+  }
+});


### PR DESCRIPTION
turbolinksのため、リロードしないとswipeが動かないため設定変更